### PR TITLE
fix: 修复密集输入时，实际执行时间比期望值略长的问题

### DIFF
--- a/app/src/main/java/com/shxyke/MaaTouch/ControlMessage.java
+++ b/app/src/main/java/com/shxyke/MaaTouch/ControlMessage.java
@@ -12,6 +12,7 @@ public final class ControlMessage {
     public static final int TYPE_EVENT_TOUCH_RESET = 4;
     public static final int TYPE_EVENT_KEY_DOWN = 5;
     public static final int TYPE_EVENT_KEY_UP = 6;
+    public static final int TYPE_EVENT_WAIT_TIMESTAMP_SYNC = 100;
 
     private int type;
     private long pointerId;
@@ -66,6 +67,12 @@ public final class ControlMessage {
 
     public static ControlMessage createWaitEvent(long milis) {
         ControlMessage msg = new ControlMessage(TYPE_EVENT_WAIT);
+        msg.millis = milis;
+        return msg;
+    }
+
+    public static ControlMessage createWaitTimestampSyncEvent(long milis) {
+        ControlMessage msg = new ControlMessage(TYPE_EVENT_WAIT_TIMESTAMP_SYNC);
         msg.millis = milis;
         return msg;
     }

--- a/app/src/main/java/com/shxyke/MaaTouch/ControlThread.java
+++ b/app/src/main/java/com/shxyke/MaaTouch/ControlThread.java
@@ -7,6 +7,7 @@ public class ControlThread {
 
     private final LinkedBlockingQueue<Queue<ControlMessage>> queue;
     private final Controller controller;
+    private long expectedNow = 0; // 理想当前时间
 
     public ControlThread(LinkedBlockingQueue<Queue<ControlMessage>> queue, Controller controller) {
         this.queue = queue;
@@ -35,10 +36,20 @@ public class ControlThread {
                 break;
             case ControlMessage.TYPE_EVENT_WAIT:
                 try {
-                    Thread.sleep(msg.getMillis());
+                    expectedNow += msg.getMillis();
+                    long timeToWait = expectedNow - System.currentTimeMillis();
+                    if (timeToWait > 0) {
+                        Thread.sleep(timeToWait);
+                    }
+                    else {
+                        expectedNow -= timeToWait;
+                    }
                 } catch (InterruptedException e) {
                     e.printStackTrace();
                 }
+                break;
+            case ControlMessage.TYPE_EVENT_WAIT_TIMESTAMP_SYNC:
+                expectedNow = msg.getMillis();
                 break;
             default:
                 break;

--- a/app/src/main/java/com/shxyke/MaaTouch/ControlThread.java
+++ b/app/src/main/java/com/shxyke/MaaTouch/ControlThread.java
@@ -18,6 +18,7 @@ public class ControlThread {
         switch (msg.getType()) {
             case ControlMessage.TYPE_EVENT_TOUCH_RESET:
                 controller.resetAll();
+                expectedNow = System.currentTimeMillis();
                 break;
             case ControlMessage.TYPE_EVENT_TOUCH_DOWN:
                 controller.injectTouchDown(msg.getPointerId(), msg.getPoint(), msg.getPressure());
@@ -49,7 +50,8 @@ public class ControlThread {
                 }
                 break;
             case ControlMessage.TYPE_EVENT_WAIT_TIMESTAMP_SYNC:
-                expectedNow = msg.getMillis();
+                if (expectedNow < msg.getMillis())
+                    expectedNow = msg.getMillis();
                 break;
             default:
                 break;

--- a/app/src/main/java/com/shxyke/MaaTouch/InputThread.java
+++ b/app/src/main/java/com/shxyke/MaaTouch/InputThread.java
@@ -106,6 +106,9 @@ public class InputThread extends Thread {
     }
 
     private void parseInput(String s) {
+        if (subqueue.isEmpty()) {
+            while(!subqueue.offer(ControlMessage.createWaitTimestampSyncEvent(System.currentTimeMillis())));
+        }
         switch (s.charAt(0)) {
             case 'c':
                 parseCommit(s);


### PR DESCRIPTION
引入一个理想当前时间 `expectedNow`, 表示执行 `waitEvent(milis)` 时应该等待至 `expectedNow + milis` 而不是 `now + milis`