### PR TITLE
fix: 修复 MaaTouch 在 Android 14 上触控崩溃的问题

### DIFF
--- a/app/src/main/java/com/shxyke/MaaTouch/wrappers/InputManager.java
+++ b/app/src/main/java/com/shxyke/MaaTouch/wrappers/InputManager.java
@@ -13,10 +13,10 @@ public final class InputManager {
     public static final int INJECT_MODE_WAIT_FOR_RESULT = 1;
     public static final int INJECT_MODE_WAIT_FOR_FINISH = 2;
 
-    private final android.hardware.input.InputManager manager;
+    private final Object manager;
     private Method injectInputEventMethod = null;
 
-    public InputManager(android.hardware.input.InputManager manager) {
+    public InputManager(Object manager) {
         this.manager = manager;
     }
 

--- a/app/src/main/java/com/shxyke/MaaTouch/wrappers/ServiceManager.java
+++ b/app/src/main/java/com/shxyke/MaaTouch/wrappers/ServiceManager.java
@@ -1,6 +1,7 @@
 package com.shxyke.MaaTouch.wrappers;
 
 import android.annotation.SuppressLint;
+import android.os.Build;
 import android.os.IBinder;
 import android.os.IInterface;
 
@@ -46,10 +47,15 @@ public final class ServiceManager {
     public InputManager getInputManager() {
         if (inputManager == null) {
             try {
-                Method getInstanceMethod = android.hardware.input.InputManager.class.getDeclaredMethod("getInstance");
-                android.hardware.input.InputManager im = (android.hardware.input.InputManager) getInstanceMethod.invoke(null);
+                Method getInstanceMethod;
+                if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                    getInstanceMethod = Class.forName("android.hardware.input.InputManagerGlobal").getMethod("getInstance");
+                } else {
+                    getInstanceMethod = android.hardware.input.InputManager.class.getDeclaredMethod("getInstance");
+                }
+                Object im = getInstanceMethod.invoke(null);
                 inputManager = new InputManager(im);
-            } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
                 e.printStackTrace();
                 throw new AssertionError(e);
             }


### PR DESCRIPTION
MaaTouch 在 Android 14 上由于 `InputManager.getInstance()` 返回不再存在，原有的逻辑被转移至 `android.hardware.input.InputManagerGlobal` 中，这个 PR 对此进行了修正。

现有的 MaaTouch
![image](https://github.com/MaaAssistantArknights/MaaTouch/assets/8038511/d4612cb0-8f30-4be1-8e29-e03ded0dcb6b)

修复后的版本替换到 MAA 程序的 `\resource\minitouch\maatouch\minitouch` 后可以正常使用。
