### PR TITLE
在 TAG 时自动发布为 PreRelease 以便 MAA 主仓库可以自动拉取最新的 MaaTouch

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -33,3 +33,12 @@ jobs:
         with:
           name: maatouch
           path: ./maatouch
+
+      - name: Release when tag is created
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: ./maatouch
+          tag_name: ${{ github.ref_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          prerelease: true


### PR DESCRIPTION
当 MaaTouch 仓库认为当前版本稳定后可以进行 TAG 操作，随后会自动将编译发布为 PreRelease

只要二次审核通过就可以将其设置为 Latest Release

这样之后 MAA 主仓库的 CI 就可以修改为自动拉取最新的 MaaTouch Release 到仓库中来完成 MaaTouch 全流程自动更新。

TAG 和 Pre Release 两次确认也可以充分确保 MaaTouch 在需要更新时被拉入主仓库而不是将任意 commit 的编译拉入主仓库。